### PR TITLE
Properties changed event

### DIFF
--- a/excess-route-manager.html
+++ b/excess-route-manager.html
@@ -324,7 +324,6 @@ setting unless you get conflicts
 - To redirect a route
   - Register the route
   - Inside routes's activate handler, abort the transition with 'redirectTo' path
-  - see https://github.com/atotic/excess-router/issues/17 for javascript example
 
 - Debugging
   - print all paths with `Excess.RouteManagerTest.print()`
@@ -374,13 +373,6 @@ setting unless you get conflicts
      * @param {boolean} options.isAliasRoute -- true if this is a aliased route
      * @param {boolean} option.activateExclusive -- true if this route can only be activated on its own
      * @param {boolean} option.activateStopPropagation -- true if no routes will match after this one
-
-     These are the transition lifecycle callbacks
-     * @param {function(transaction)} options.willDeactivate --
-     * @param {function(transaction)} options.deactivate --
-     * @param {function(transaction, { routeParams: {} }) , function done} options.willActivate --
-     * @param {function(transaction, { routeParams: {} }) , function done} options.activate --
-
      * @return {string}} -- token, you need this to unregister
      */
     register: function(path, options) {
@@ -659,6 +651,7 @@ setting unless you get conflicts
     },
 
     _setRouteFromLocation: function() {
+      var event = new Event('route-set');
       var path = this._extractLocationPath();
       // console.log('_setRouteFromLocation', path);
       if (!path) {
@@ -676,6 +669,7 @@ setting unless you get conflicts
           }
         );
         RouterState.startTransition(transition);
+        window.dispatchEvent(event);
       }
       else {
         console.warn('no matching routes found in popstate');

--- a/excess-route-manager.html
+++ b/excess-route-manager.html
@@ -324,6 +324,7 @@ setting unless you get conflicts
 - To redirect a route
   - Register the route
   - Inside routes's activate handler, abort the transition with 'redirectTo' path
+  - see https://github.com/atotic/excess-router/issues/17 for javascript example
 
 - Debugging
   - print all paths with `Excess.RouteManagerTest.print()`
@@ -373,6 +374,13 @@ setting unless you get conflicts
      * @param {boolean} options.isAliasRoute -- true if this is a aliased route
      * @param {boolean} option.activateExclusive -- true if this route can only be activated on its own
      * @param {boolean} option.activateStopPropagation -- true if no routes will match after this one
+
+     These are the transition lifecycle callbacks
+     * @param {function(transaction)} options.willDeactivate --
+     * @param {function(transaction)} options.deactivate --
+     * @param {function(transaction, { routeParams: {} }) , function done} options.willActivate --
+     * @param {function(transaction, { routeParams: {} }) , function done} options.activate --
+
      * @return {string}} -- token, you need this to unregister
      */
     register: function(path, options) {

--- a/excess-route.html
+++ b/excess-route.html
@@ -261,8 +261,19 @@ How would you use this in Polymer Starter Kit?
      * @param {object} detail
      * @param {object} detail.activationParams
      */
+    
+    /**
+     * Fired after properties have been set.
+     *
+     * @event properties-changed
+     */
 
     created: function() {
+      window.addEventListener('route-set', function() {
+        if (this.routeParams) {
+          this.fire('properties-changed');
+        }
+      }.bind(this));
       this._boundWillDeactivate = this._willDeactivate.bind(this);
       this._boundDeactivate = this._deactivate.bind(this);
       this._boundWillActivate = this._willActivate.bind(this);


### PR DESCRIPTION
I added an event that fires after the properties have been updated.  It is extremely inefficient and difficult for me to use this element without an event that fires after the properties have been updated.  Without this event, I have to create an observer that listens for the properties to change.  This is ok except for when I have multiple properties in a route.  If I try and listen for the properties to change with multiple properties, the observers fire once for each property, and the first time it fires, the second property hasn't been set yet, so I have to program my software to ignore the first time the event fires.  Additionally, if I have the same variable used for different routes, the observers will not fire when the route changes if the variables don't change.  For example, if http://localhost/foo/bar changes to http://foo, and 'foo' is bound to the same variable in both routes, my observer will not fire.

In summary, it is extremely difficult and almost impossible to use excess-router in certain advanced cases without an event firing after all the properties have been set.  I would appreciate if you would accept this pull request so I don't have to create my own branch of excess-router and worry about keeping it updated.  If you have a better way of doing this, please let me know.
