### PR TITLE
added ability to open internal links in new tab (target=_blank)

### DIFF
--- a/excess-route-manager.html
+++ b/excess-route-manager.html
@@ -683,12 +683,15 @@ setting unless you get conflicts
     },
 
     _routeAnchor: function(anchor) {
-	  do {
-		if (anchor.nodeName === 'A') break;
-	  } while (anchor.parentNode && (anchor = anchor.parentNode));
+  	  do {
+  		if (anchor.nodeName === 'A') break;
+  	  } while (anchor.parentNode && (anchor = anchor.parentNode));
 
-	  if (anchor.nodeName !== 'A')
-		return false;
+      if (anchor.target === '_blank')
+        return false;
+
+  	  if (anchor.nodeName !== 'A')
+  		  return false;
 
       if (anchor.protocol === 'javascript:')
         return false;


### PR DESCRIPTION
All links with target set to "_blank" will now open in a new tab. Before, this behavior only applied to external links, making it impossible to have internal links open in a new tab.  
