### PR TITLE
Added excess-route-manager dependency in execes route

### DIFF
--- a/excess-route.html
+++ b/excess-route.html
@@ -1,4 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="excess-route-manager.html">
+
 <!--
 ## excess-router
 


### PR DESCRIPTION
The route-manager needs to be initialized prior of the excess-route component.
Using vulcanize, it may happen, that within an resulting merged JS File, the excess-route is called before the manager, which crashes the app.

Adding the import forces vulcanize to have correct order.
